### PR TITLE
 Set metrics prefix from a system property. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,39 +21,32 @@ Do the following steps to start sending Knot.x application metrics to Graphite:
 ```json
     {
       "groupId": "io.knotx",
-      "artifactId": "metrics-sender",
+      "artifactId": "knotx-dashboard",
       "version": "X.Y.Z",
       "included": true
     }
 ```
 * Run `bin\knotx resolve` to resolve new dependencies and add `metrics-sender` to the instance classpath
-* Add `metrics-sender` entry to `application.conf` modules list
+* Add `metricSender` entry to `application.conf` modules list
 ```
 "metricsSender=io.knotx.metrics.SenderVerticle"
 ```
-* Copy `conf/dashboardStack.conf` to application `conf` folder
-* Add `dashboardStack.conf` to application stores defined in `bootstrap.json`, e.g.
-```json
-...
-    "stores": [
-      ...
-    
-      {
-        "type": "file",
-        "format": "conf",
-        "config": {
-          "path": "${KNOTX_HOME}/conf/dashboardStack.conf"
-        }
-      }
-    ]
-...
+* Add `metricSender` entry to `application.conf` modules configuration
 ```
+config.metricsSender {
+  options.config {
+    include required("includes/metricsSender.conf")
+  }
+}
+```
+* Copy `conf/metricsSender.conf` to application `conf/includes` folder
 * Define Graphite connection in `conf/dashboardStack.conf` (by default it's set to `localhost:2003`).
 * Uncomment `METRICS_OPTS` line in `bin/knotx`:
 ```cmd
 METRICS_OPTS="-Dvertx.metrics.options.enabled=true -Dvertx.metrics.options.registryName=knotx-dropwizard-registry"
 ```
-* Optionally configure other metrics sender parameters in `conf/dashboardStack.conf`
+* Optionally add -Dknotx.metrics.options.prefix=<custom prefix> to `METRICS_OPTS`
+* Optionally configure other metrics sender parameters in `conf/includes/metricsSender.conf`
 * Optionally configure metrics to gather event-bus data:
   - copy `conf/metrics-options.json` to `conf` directory of Knot.x instance
   - append `METRICS_OPTS` in `bin/knotx` with `-Dvertx.metrics.options.configPath=conf/metrics-options.json`

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ config.metricsSender {
 ```cmd
 METRICS_OPTS="-Dvertx.metrics.options.enabled=true -Dvertx.metrics.options.registryName=knotx-dropwizard-registry"
 ```
-* Optionally add -Dknotx.metrics.options.prefix=<custom prefix> to `METRICS_OPTS`
+* Optionally add `-Dknotx.metrics.options.prefix=<custom prefix>` to `METRICS_OPTS`
 * Optionally configure other metrics sender parameters in `conf/includes/metricsSender.conf`
 * Optionally configure metrics to gather event-bus data:
   - copy `conf/metrics-options.json` to `conf` directory of Knot.x instance

--- a/README.md
+++ b/README.md
@@ -31,15 +31,23 @@ Do the following steps to start sending Knot.x application metrics to Graphite:
 ```
 "metricsSender=io.knotx.metrics.SenderVerticle"
 ```
-* Add `metricSender` entry to `application.conf` modules configuration
+* Copy `conf/dashboardStack.conf` to application `conf` folder
+* Add `dashboardStack.conf` to application stores defined in `bootstrap.json`, e.g.
+```json
+...
+    "stores": [
+      ...
+    
+      {
+        "type": "file",
+        "format": "conf",
+        "config": {
+          "path": "${KNOTX_HOME}/conf/dashboardStack.conf"
+        }
+      }
+    ]
+...
 ```
-config.metricsSender {
-  options.config {
-    include required("includes/metricsSender.conf")
-  }
-}
-```
-* Copy `conf/metricsSender.conf` to application `conf/includes` folder
 * Define Graphite connection in `conf/dashboardStack.conf` (by default it's set to `localhost:2003`).
 * Uncomment `METRICS_OPTS` line in `bin/knotx`:
 ```cmd

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Do the following steps to start sending Knot.x application metrics to Graphite:
 METRICS_OPTS="-Dvertx.metrics.options.enabled=true -Dvertx.metrics.options.registryName=knotx-dropwizard-registry"
 ```
 * Optionally add `-Dknotx.metrics.options.prefix=<custom prefix>` to `METRICS_OPTS`
-* Optionally configure other metrics sender parameters in `conf/includes/metricsSender.conf`
+* Optionally configure other metrics sender parameters in `conf/dashboardStack.conf`
 * Optionally configure metrics to gather event-bus data:
   - copy `conf/metrics-options.json` to `conf` directory of Knot.x instance
   - append `METRICS_OPTS` in `bin/knotx` with `-Dvertx.metrics.options.configPath=conf/metrics-options.json`

--- a/conf/dashboardStack.conf
+++ b/conf/dashboardStack.conf
@@ -1,19 +1,9 @@
 ########### Add the entry below to application.conf modules list ###########
-# "metricsSender=io.knotx.metrics.SenderVerticle"
+"metricsSender=io.knotx.metrics.SenderVerticle"
 
-########### Modules configurations ###########
+########### Add the below to application.conf modules configuration ###########
 config.metricsSender {
   options.config {
-    # Metrics data prefix
-    prefix = "io.knotx"
-
-    # How often (seconds) should metrics be send
-    pollsPeriod: 1
-
-    # Graphite endpoint connection
-    graphite {
-      address: "localhost"
-      port: 2003
-    }
+    include required("includes/metricsSender.conf")
   }
 }

--- a/conf/metricsSender.conf
+++ b/conf/metricsSender.conf
@@ -1,0 +1,11 @@
+# Metrics data prefix, can be overridden by system property 'knotx.metrics.options.prefix'
+prefix = "io.knotx"
+
+# How often (seconds) should metrics be send
+pollsPeriod: 1
+
+# Graphite endpoint connection
+graphite {
+  address: "localhost"
+  port: 2003
+}

--- a/metrics-sender/src/main/java/io/knotx/metrics/SenderVerticle.java
+++ b/metrics-sender/src/main/java/io/knotx/metrics/SenderVerticle.java
@@ -30,7 +30,6 @@ public class SenderVerticle extends AbstractVerticle {
   @Override
   public void start() throws Exception {
     LOGGER.info("Starting <{}>", this.getClass().getSimpleName());
-    LOGGER.debug("Metrics config: {}", options);
 
     MetricRegistry dropwizardRegistry = SharedMetricRegistries.getOrCreate(
         System.getProperty("vertx.metrics.options.registryName")
@@ -39,7 +38,7 @@ public class SenderVerticle extends AbstractVerticle {
     final Graphite graphite = new Graphite(
         new InetSocketAddress(graphiteOptions.getAddress(), graphiteOptions.getPort()));
     final GraphiteReporter reporter = GraphiteReporter.forRegistry(dropwizardRegistry)
-        .prefixedWith(options.getPrefix())
+        .prefixedWith(System.getProperty("knotx.metrics.options.prefix", options.getPrefix()))
         .convertRatesTo(TimeUnit.SECONDS)
         .convertDurationsTo(TimeUnit.MILLISECONDS)
         .filter(MetricFilter.ALL)

--- a/metrics-sender/src/main/java/io/knotx/metrics/SenderVerticle.java
+++ b/metrics-sender/src/main/java/io/knotx/metrics/SenderVerticle.java
@@ -38,7 +38,7 @@ public class SenderVerticle extends AbstractVerticle {
 
     final String registryName = System.getProperty(REGISTRY_PROPERTY);
     if (registryName == null) {
-      LOGGER.warn("Property '{}' not set. Exiting.", REGISTRY_PROPERTY);
+      LOGGER.error("Property '{}' not set. Exiting.", REGISTRY_PROPERTY);
       return;
     }
 


### PR DESCRIPTION
New command line option `-Dknotx.metrics.options.prefix` to control the prefix.
+ The example configuration updated.