### PR TITLE
Make metricsSender.conf use milliseconds instead of seconds to define poll period

### DIFF
--- a/conf/metricsSender.conf
+++ b/conf/metricsSender.conf
@@ -1,8 +1,8 @@
 # Metrics data prefix, can be overridden by system property 'knotx.metrics.options.prefix'
 prefix = "io.knotx"
 
-# How often (seconds) should metrics be send
-pollsPeriod: 1
+# How often (milliseconds) should metrics be sent
+pollsPeriod: 1000
 
 # Graphite endpoint connection
 graphite {


### PR DESCRIPTION
The `pollPeriod` value in `metricsSender.conf` is interpreted as milliseconds in
`MetricsSenderOptions`. The default values provided here were
erroneously expressed in seconds instead, leading to cascading failures
caused by Knot.X attempting to send a full set of Vert.x metrics every
millisecond.